### PR TITLE
added remote-env arg

### DIFF
--- a/support/retro_contest/docker.py
+++ b/support/retro_contest/docker.py
@@ -91,7 +91,7 @@ def run(game, state=None, entry=None, **kwargs):
         datamount[convert_path(data_path())] = {'bind': '/root/data', 'mode': 'ro'}
 
     try:
-        remote = client.containers.run('openai/retro-env', remote_command,
+        remote = client.containers.run(kwargs['remote_env'], remote_command,
                                        volumes={volname: {'bind': '/root/compo/tmp'},
                                                 **datamount},
                                        **remote_kwargs)
@@ -196,6 +196,7 @@ def run_args(args):
         'wallclock_limit': args.wallclock_limit,
         'timestep_limit': args.timestep_limit,
         'discrete_actions': args.discrete_actions,
+        'remote_env': args.remote_env,
         'resultsdir': args.results_dir,
         'agentdir': args.agent_dir,
         'quiet': args.quiet,
@@ -287,6 +288,7 @@ def init_parser(subparsers):
     parser_run.add_argument('--wallclock-limit', '-W', type=float, default=None, help='Maximum time to run in seconds')
     parser_run.add_argument('--timestep-limit', '-T', type=int, default=None, help='Maximum time to run in timesteps')
     parser_run.add_argument('--no-nv', '-N', action='store_true', help='Disable Nvidia runtime')
+    parser_run.add_argument('--remote-env', '-R', type=str, default='openai/retro-env', help='Remote Docker image')
     parser_run.add_argument('--results-dir', '-r', type=str, help='Path to output results')
     parser_run.add_argument('--agent-dir', '-o', type=str, help='Path to mount into agent (mounted at /root/compo/out)')
     parser_run.add_argument('--discrete-actions', '-D', action='store_true', help='Use a discrete action space')


### PR DESCRIPTION
Added parser argument `--remote-env` with alias `-R` when calling `retro-contest run` to allow for any docker image to be used for the remote container, instead of only `openai/retro-env`.  The default remote image is still `openai/retro-env`.

I wanted to be able to create a dockerfile from `openai/retro-env` without having to tag over it in order to use `retro-contest run`.