### PR TITLE
Fixed an issue where docker.py could not run independently

### DIFF
--- a/support/retro_contest/docker.py
+++ b/support/retro_contest/docker.py
@@ -309,7 +309,8 @@ def init_parser(subparsers):
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='Run OpenAI Retro Contest support code')
-    init_parser(parser)
+    parser.set_defaults(func=lambda args: parser.print_help())
+    init_parser(parser.add_subparsers())
     args = parser.parse_args(argv)
     if not args.func(args):
         sys.exit(1)


### PR DESCRIPTION
I discovered and _I think_ fixed a dependency between `__main__` and `docker.py` where `docker.py` was relying implicitly on `__main__` adding subparsers and setting defaults, thereby not allowing `docker.py` to run independently (e.g. via `$python3 docker.py`). 