### PR TITLE
Added main() to rest.py to allow for independent execution

### DIFF
--- a/support/retro_contest/rest.py
+++ b/support/retro_contest/rest.py
@@ -5,8 +5,8 @@ import itertools
 import json
 import os
 import requests
-import yaml
 import sys
+import yaml
 from functools import wraps
 from requests.auth import HTTPBasicAuth
 
@@ -337,6 +337,7 @@ def init_parsers(subparsers):
     parser_job_submit = subparsers_job.add_parser('submit', description='Submit new job')
     parser_job_submit.set_defaults(func=submit_args)
     parser_job_submit.add_argument('-t', '--tag', type=str, help='Local tag to push')
+
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='Run OpenAI Retro Contest support code')

--- a/support/retro_contest/rest.py
+++ b/support/retro_contest/rest.py
@@ -6,6 +6,7 @@ import json
 import os
 import requests
 import yaml
+import sys
 from functools import wraps
 from requests.auth import HTTPBasicAuth
 
@@ -336,3 +337,15 @@ def init_parsers(subparsers):
     parser_job_submit = subparsers_job.add_parser('submit', description='Submit new job')
     parser_job_submit.set_defaults(func=submit_args)
     parser_job_submit.add_argument('-t', '--tag', type=str, help='Local tag to push')
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description='Run OpenAI Retro Contest support code')
+    parser.set_defaults(func=lambda args: parser.print_help())
+    init_parsers(parser.add_subparsers())
+    args = parser.parse_args(argv)
+    if not args.func(args):
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I was scripting stuff and wished I could `import retro_contest.rest` and call `main(args)` instead of doing a bunch of `subprocess` crud. I tried to follow in the footsteps of `remote.py` and `docker.py`.