### PR TITLE
Import gym.wrappers explicitly

### DIFF
--- a/support/retro_contest/local.py
+++ b/support/retro_contest/local.py
@@ -1,6 +1,7 @@
 import retro
 import retro_contest
 import gym
+import gym.wrappers
 
 
 def make(game, state=retro.State.DEFAULT, discrete_actions=False, bk2dir=None):


### PR DESCRIPTION
Newer versions of gym don't import `gym.wrappers` by default (see: https://github.com/openai/gym/pull/1154), hence `make` throws an error. This PR fixes the error. 